### PR TITLE
Small fixes for docker-worker integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "compile": "babel-compile -p taskcluster src:lib test-src:test",
+    "install": "yarn compile",
     "pretest": "yarn compile",
     "prepublish": "yarn compile",
     "test": "DEBUG= mocha"

--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,18 @@ class Artifact {
 
   /**
    * Get a URL from the Taskcluster Queue based on task metadata
+   *
+   * If runId is not given, the latest run of the taskId is used.
    */
   async get({taskId, runId, name, filename}) {
-    let url = this.__queue.buildUrl(this.__queue.getArtifact, taskId, runId, name);
+    let url;
+    
+    if (runId === undefined) {
+      url = this.__queue.buildUrl(this.__queue.getLatestArtifact, taskId, name);
+    } else {
+      url = this.__queue.buildUrl(this.__queue.getArtifact, taskId, runId, name);
+    }
+
     await this.__client.downloadUrl({url, output: filename});
   }
 


### PR DESCRIPTION
* Use `install` script to build the library when we do `yarn install`
* Download an artifact from the latest run when `runId` is not given.