### PR TITLE
Make tests pass against production Queue workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
     "commander": "^2.11.0",
-    "remotely-signed-s3": "^2.0.0"
+    "remotely-signed-s3": "^3.1.0"
   },
   "devDependencies": {
     "assume": "^1.5.1",

--- a/test-src/integration_test.js
+++ b/test-src/integration_test.js
@@ -37,9 +37,14 @@ describe('taskcluster-lib-artifact', () => {
   let expires = new Date();
   expires.setDate(expires.getDate() + 1);
 
-  beforeEach(() => {
-    queue = new Queue({});
+  beforeEach(async () => {
+    queue = new Queue({bucket: 'test-bucket-for-any-garbage', port: 30000});
+    await queue.start();
     subject = new Artifact({queue});
+  });
+
+  afterEach(async () => {
+    await queue.stop();
   });
 
   describe('helper functions', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,9 +1238,9 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-remotely-signed-s3@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/remotely-signed-s3/-/remotely-signed-s3-2.0.0.tgz#37a202a55974299f5f77aab0d0430ceb755298a7"
+remotely-signed-s3@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/remotely-signed-s3/-/remotely-signed-s3-3.1.0.tgz#afc522e2189fd60073761851475a802569a16dba"
   dependencies:
     aws4 "^1.6.0"
     babel-runtime "^6.23.0"


### PR DESCRIPTION
Because I wasn't able to test against the real queue, I didn't notice that my
code wasn't working.  This commit makes the mock queue in this library function
much closer to that of the real queue.

At some point, ripping out the mock queue would probably be a good idea, but
for now I'll keep things simple